### PR TITLE
fix: use NSObject in place fo UIViewController and remove GADGetStrin…

### DIFF
--- a/src/Jc.GMA.iOS/Extensions.cs
+++ b/src/Jc.GMA.iOS/Extensions.cs
@@ -81,10 +81,6 @@ namespace Google.MobileAds {
 		[DllImport ("__Internal", EntryPoint = "GADAdSizeFromNSValue")]
 		public static extern AdSize _GetFromNSValue (IntPtr value);
 		
-		// NSString *_Nonnull GADGetStringFromVersionNumber(GADVersionNumber version)
-		[DllImport ("__Internal", EntryPoint = "GADGetStringFromVersionNumber")]
-		public static extern string GetStringFromVersionNumber (VersionNumber version);
-
 		public static NSString GetNSString (AdSize size)
 		{
 			return Runtime.GetNSObject<NSString> (_GetNSString (size));

--- a/src/Jc.GMA.iOS/Jc.GMA.iOS.csproj
+++ b/src/Jc.GMA.iOS/Jc.GMA.iOS.csproj
@@ -13,7 +13,7 @@
 		<Description>Google Mobile Ads SDK iOS Bindings.</Description>
 		<PackageProjectUrl>https://jcsawyer.com/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/jcsawyer/Jc.GoogleMobileAds.iOS/tree/main</RepositoryUrl>
-		<Version>9.14.0-preview200</Version>
+		<Version>9.14.0-preview300</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Jc.UMP.iOS/ApiDefinition.cs
+++ b/src/Jc.UMP.iOS/ApiDefinition.cs
@@ -30,7 +30,7 @@ namespace Google.UserMessagingPlatform
 		// + (void)loadAndPresentIfRequiredFromViewController:(nullable UIViewController *)viewController completionHandler: (nullable UMPConsentFormPresentCompletionHandler) completionHandler;
 		[Static]
 		[Export("loadAndPresentIfRequiredFromViewController:completionHandler:")]
-		void LoadAndPresentIfRequiredFromViewController([NullAllowed] UIViewController viewController, [NullAllowed] ConsentFormPresentCompletionHandler completionHandler);
+		void LoadAndPresentIfRequiredFromViewController([NullAllowed] NSObject viewController, [NullAllowed] ConsentFormPresentCompletionHandler completionHandler);
 		
 		// +(void)loadWithCompletionHandler:(UMPConsentFormLoadCompletionHandler _Nonnull)completionHandler;
 		[Static]

--- a/src/Jc.UMP.iOS/Jc.UMP.iOS.csproj
+++ b/src/Jc.UMP.iOS/Jc.UMP.iOS.csproj
@@ -13,7 +13,7 @@
         <Description>User Messaging Platform iOS Bindings.</Description>
         <PackageProjectUrl>https://jcsawyer.com/</PackageProjectUrl>
         <RepositoryUrl>https://github.com/jcsawyer/Jc.GoogleMobileAds.iOS/tree/main</RepositoryUrl>
-        <Version>2.7.1-preview100</Version>
+        <Version>2.7.1-preview200</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
…gFromVersionNumber

- `UIViewController` binding not being found - attempting this as previous present binding just accepted and `NSObject`
- GADGetStringFromVersionNumber doesn't appear to be within the binary when running `nm -gU GoogleMobileAds | grep GADGetStringFromVersionNumber`
  - Will investigate but may be solved by upgrade to v10.