### PR TITLE
fix: update api definitions for GADRequest and GAMRequest

### DIFF
--- a/src/Jc.GMA.iOS/ApiDefinition.cs
+++ b/src/Jc.GMA.iOS/ApiDefinition.cs
@@ -374,6 +374,10 @@ namespace Google.MobileAds
 
         [Export("removeAdNetworkExtrasFor:")]
         void RemoveAdNetworkExtrasFor(Class aClass);
+        
+        [NullAllowed]
+        [Export("scene", ArgumentSemantic.Weak)]
+        UIWindowScene Scene { get; set; }
 
         [Export("setLocationWithLatitude:longitude:accuracy:")]
         void SetLocation(nfloat latitude, nfloat longitude, nfloat accuracyInMeters);
@@ -393,6 +397,10 @@ namespace Google.MobileAds
         [NullAllowed]
         [Export("requestAgent", ArgumentSemantic.Copy)]
         string RequestAgent { get; set; }
+        
+        [NullAllowed]
+        [Export("customTargeting", ArgumentSemantic.Copy)]
+        NSDictionary<NSString, NSString> CustomTargeting { get; set; }
     }
 
     [Static]
@@ -2615,6 +2623,11 @@ namespace Google.MobileAds.DoubleClick
     [BaseType(typeof(Google.MobileAds.Request), Name = "GAMRequest")]
     interface Request
     {
+        [New]
+        [Static]
+        [Export ("request")]
+        Request GetDefaultRequest ();
+        
         [NullAllowed]
         [Export("publisherProvidedID", ArgumentSemantic.Copy)]
         string PublisherProvidedID { get; set; }

--- a/src/Jc.GMA.iOS/Jc.GMA.iOS.csproj
+++ b/src/Jc.GMA.iOS/Jc.GMA.iOS.csproj
@@ -15,7 +15,7 @@
 		<RepositoryUrl>https://github.com/jcsawyer/Jc.GoogleMobileAds.iOS/tree/main</RepositoryUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>11.13.3</Version>
+		<Version>11.13.4</Version>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This pull request updates the `GAMRequest` binding in the `ApiDefinitions` file to address missing base members and improve functionality. Key changes include:

- Added support for customTargeting and other previously omitted properties to ensure complete compatibility with the Google Mobile Ads SDK.
- Implemented related adjustments to maintain consistency and functionality across the binding.

These corrections enhance the accuracy and usability of the iOS binding for developers integrating Google Ad Manager features.