### PR TITLE
feat!: add compiler warning for supported os version and update .net targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Each major version contains breaking changes according to the Google AdMob SDK. 
 The headline changes relevant will be listed here.
 
 ## v12.2.2
+
 `AdSizeCons` constants were changed to be hardcoded while I try to find a better approach to access the true values.
 This means that values will be the same for both iPhone and iPad.
 
@@ -24,18 +25,7 @@ This means that values will be the same for both iPhone and iPad.
   - Note: SDK 11.0.0 still builds on iOS 12 devices, but ads will not serve.
 - armv7 support has been removed from the SDK
 
-More info can be found [here](https://developers.google.com/admob/ios/migration#migrate_from_v9_to_v10)
-
-### Usage
-
-To use Jc.GoogleMobileAds.iOS, you can add the required packages to your project:
-
-```
-dotnet add package Jc.GMA.iOS
-dotnet add package Jc.UMP.iOS
-```
-
-To use the latest `v11.13.0`, you must add this target to your csproj file to support linking with Swift system libraries
+From `v11.13.0` and beyond, you must add this target to your csproj file to support linking with Swift system libraries
 
 ```xml
 <Target Name="LinkWithSwift" DependsOnTargets="_ParseBundlerArguments;_DetectSdkLocations" BeforeTargets="_LinkNativeExecutable">
@@ -52,4 +42,34 @@ To use the latest `v11.13.0`, you must add this target to your csproj file to su
         <_CustomLinkFlags Include="-Wl,/usr/lib/swift" />
     </ItemGroup>
 </Target>
+```
+
+More info can be found [here](https://developers.google.com/admob/ios/migration#migrate_from_v9_to_v10)
+
+### Usage
+
+To use Jc.GoogleMobileAds.iOS, you can add the required packages to your project:
+
+```
+dotnet add package Jc.GMA.iOS
+dotnet add package Jc.UMP.iOS
+```
+
+Ensure that the `SupportedOSPlatformVersion` attribute in your project file is set to `15.0` or higher:
+
+```xml
+<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+```
+
+along with setting it in the `Info.plist` file:
+
+```xml
+<key>MinimumOSVersion</key>
+<string>15.0</string>
+```
+
+Failing to set the minimum version will result in the compiler warning:
+
+```
+Jc.*.iOS requires a minimum SupportedOSPlatformVersion of 15.0. Update your project to target iOS 15 or later.
 ```

--- a/src/Jc.GMA.iOS/Jc.GMA.iOS.csproj
+++ b/src/Jc.GMA.iOS/Jc.GMA.iOS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-ios;net9.0-ios</TargetFrameworks>
+		<TargetFramework>net10.0-ios</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>true</ImplicitUsings>
 		<IsBindingProject>true</IsBindingProject>
@@ -15,7 +15,8 @@
 		<RepositoryUrl>https://github.com/jcsawyer/Jc.GoogleMobileAds.iOS/tree/main</RepositoryUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>12.7.0-preview100</Version>
+		<Version>12.7.0</Version>
+		<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -23,8 +24,9 @@
 		<ObjcBindingCoreSource Include="StructsAndEnums.cs" />
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 		<None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+		<None Include="Jc.GMA.iOS.targets" Pack="true" PackagePath="buildTransitive" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<NativeReference Include="GMA.xcframework">
 			<Kind>Framework</Kind>

--- a/src/Jc.GMA.iOS/Jc.GMA.iOS.csproj
+++ b/src/Jc.GMA.iOS/Jc.GMA.iOS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net10.0-ios</TargetFramework>
+		<TargetFrameworks>net9.0-ios;net10.0-ios</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>true</ImplicitUsings>
 		<IsBindingProject>true</IsBindingProject>

--- a/src/Jc.GMA.iOS/Jc.GMA.iOS.targets
+++ b/src/Jc.GMA.iOS/Jc.GMA.iOS.targets
@@ -1,0 +1,13 @@
+<Project>
+    <PropertyGroup>
+        <!-- Make sure SupportedOSPlatformVersion is set somewhere in your library -->
+        <_IosVersionNumber>$([System.Double]::Parse($(SupportedOSPlatformVersion)))</_IosVersionNumber>
+    </PropertyGroup>
+
+
+    <!-- Fail the build if the consumer targets < iOS 15 -->
+        <Target Name="CheckIosVersion" BeforeTargets="Build" Condition="$(TargetPlatformIdentifier) == 'ios'">
+            <Warning Condition="'$(SupportedOSPlatformVersion)' != '' and $(TargetPlatformVersion) != '' and $([MSBuild]::VersionLessThan($(SupportedOSPlatformVersion), 15))"
+                   Text="Jc.GMA.iOS requires a minimum SupportedOSPlatformVersion of 15.0. Update your project to target iOS 15 or later." />
+        </Target>
+</Project>

--- a/src/Jc.UMP.iOS/Jc.UMP.iOS.csproj
+++ b/src/Jc.UMP.iOS/Jc.UMP.iOS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0-ios;net9.0-ios</TargetFrameworks>
+        <TargetFramework>net10.0-ios</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>true</ImplicitUsings>
         <IsBindingProject>true</IsBindingProject>
@@ -15,7 +15,8 @@
         <RepositoryUrl>https://github.com/jcsawyer/Jc.GoogleMobileAds.iOS/tree/main</RepositoryUrl>
         <PacakgeReadmeFile>README.md</PacakgeReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>2.7.4-preview100</Version>
+        <Version>2.7.4</Version>
+		<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -23,6 +24,7 @@
         <ObjcBindingCoreSource Include="StructsAndEnums.cs"/>
         <None Include="..\..\README.md" Pack="true" PackagePath="\" />
         <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+		<None Include="Jc.UMP.iOS.targets" Pack="true" PackagePath="buildTransitive" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Jc.UMP.iOS/Jc.UMP.iOS.csproj
+++ b/src/Jc.UMP.iOS/Jc.UMP.iOS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net10.0-ios</TargetFramework>
+        <TargetFrameworks>net9.0-ios;net10.0-ios</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>true</ImplicitUsings>
         <IsBindingProject>true</IsBindingProject>

--- a/src/Jc.UMP.iOS/Jc.UMP.iOS.targets
+++ b/src/Jc.UMP.iOS/Jc.UMP.iOS.targets
@@ -1,0 +1,13 @@
+<Project>
+    <PropertyGroup>
+        <!-- Make sure SupportedOSPlatformVersion is set somewhere in your library -->
+        <_IosVersionNumber>$([System.Double]::Parse($(SupportedOSPlatformVersion)))</_IosVersionNumber>
+    </PropertyGroup>
+
+
+    <!-- Fail the build if the consumer targets < iOS 15 -->
+        <Target Name="CheckIosVersion" BeforeTargets="Build" Condition="$(TargetPlatformIdentifier) == 'ios'">
+            <Warning Condition="'$(SupportedOSPlatformVersion)' != '' and $(TargetPlatformVersion) != '' and $([MSBuild]::VersionLessThan($(SupportedOSPlatformVersion), 15))"
+                   Text="Jc.UMP.iOS requires a minimum SupportedOSPlatformVersion of 15.0. Update your project to target iOS 15 or later." />
+        </Target>
+</Project>


### PR DESCRIPTION
- Drop .net8.0-ios support
- Add .net10.0-ios support
- Add compiler warning for supportedosplatfomversion < 15.0

<img width="1202" height="29" alt="image" src="https://github.com/user-attachments/assets/5d783747-e174-45fd-ad9f-d59d2f0b4810" />
#52  #47 