### PR TITLE
fix: use System.Version for IosVersionNumber parsing

### DIFF
--- a/src/Jc.GMA.iOS/Jc.GMA.iOS.csproj
+++ b/src/Jc.GMA.iOS/Jc.GMA.iOS.csproj
@@ -15,7 +15,7 @@
 		<RepositoryUrl>https://github.com/jcsawyer/Jc.GoogleMobileAds.iOS/tree/main</RepositoryUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>12.7.1</Version>
+		<Version>12.7.1-preview100</Version>
 		<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 

--- a/src/Jc.GMA.iOS/Jc.GMA.iOS.csproj
+++ b/src/Jc.GMA.iOS/Jc.GMA.iOS.csproj
@@ -15,7 +15,7 @@
 		<RepositoryUrl>https://github.com/jcsawyer/Jc.GoogleMobileAds.iOS/tree/main</RepositoryUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>12.7.0</Version>
+		<Version>12.7.1</Version>
 		<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 

--- a/src/Jc.GMA.iOS/Jc.GMA.iOS.targets
+++ b/src/Jc.GMA.iOS/Jc.GMA.iOS.targets
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <!-- Make sure SupportedOSPlatformVersion is set somewhere in your library -->
-        <_IosVersionNumber>$([System.Double]::Parse($(SupportedOSPlatformVersion)))</_IosVersionNumber>
+        <_IosVersionNumber>$([System.Double]::Parse($(SupportedOSPlatformVersion, $([System.Globalization.CultureInfo]::InvariantCulture))))</_IosVersionNumber>
     </PropertyGroup>
 
 

--- a/src/Jc.GMA.iOS/Jc.GMA.iOS.targets
+++ b/src/Jc.GMA.iOS/Jc.GMA.iOS.targets
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <!-- Make sure SupportedOSPlatformVersion is set somewhere in your library -->
-        <_IosVersionNumber>$([System.Double]::Parse($(SupportedOSPlatformVersion, $([System.Globalization.CultureInfo]::InvariantCulture))))</_IosVersionNumber>
+        <_IosVersionNumber Condition="$(TargetPlatformIdentifier) == 'ios'">$([System.Version]::Parse($(SupportedOSPlatformVersion)))</_IosVersionNumber>
     </PropertyGroup>
 
 

--- a/src/Jc.UMP.iOS/Jc.UMP.iOS.csproj
+++ b/src/Jc.UMP.iOS/Jc.UMP.iOS.csproj
@@ -15,7 +15,7 @@
         <RepositoryUrl>https://github.com/jcsawyer/Jc.GoogleMobileAds.iOS/tree/main</RepositoryUrl>
         <PacakgeReadmeFile>README.md</PacakgeReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>2.7.4</Version>
+        <Version>2.7.5</Version>
 		<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     </PropertyGroup>
 

--- a/src/Jc.UMP.iOS/Jc.UMP.iOS.csproj
+++ b/src/Jc.UMP.iOS/Jc.UMP.iOS.csproj
@@ -15,7 +15,7 @@
         <RepositoryUrl>https://github.com/jcsawyer/Jc.GoogleMobileAds.iOS/tree/main</RepositoryUrl>
         <PacakgeReadmeFile>README.md</PacakgeReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>2.7.5</Version>
+        <Version>2.7.5-preview100</Version>
 		<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     </PropertyGroup>
 

--- a/src/Jc.UMP.iOS/Jc.UMP.iOS.targets
+++ b/src/Jc.UMP.iOS/Jc.UMP.iOS.targets
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <!-- Make sure SupportedOSPlatformVersion is set somewhere in your library -->
-        <_IosVersionNumber>$([System.Double]::Parse($(SupportedOSPlatformVersion)))</_IosVersionNumber>
+        <_IosVersionNumber>$([System.Double]::Parse($(SupportedOSPlatformVersion, $([System.Globalization.CultureInfo]::InvariantCulture))))</_IosVersionNumber>
     </PropertyGroup>
 
 

--- a/src/Jc.UMP.iOS/Jc.UMP.iOS.targets
+++ b/src/Jc.UMP.iOS/Jc.UMP.iOS.targets
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <!-- Make sure SupportedOSPlatformVersion is set somewhere in your library -->
-        <_IosVersionNumber>$([System.Double]::Parse($(SupportedOSPlatformVersion, $([System.Globalization.CultureInfo]::InvariantCulture))))</_IosVersionNumber>
+        <_IosVersionNumber Condition="$(TargetPlatformIdentifier) == 'ios'">$([System.Version]::Parse($(SupportedOSPlatformVersion)))</_IosVersionNumber>
     </PropertyGroup>
 
 


### PR DESCRIPTION
Attempt to fix #56 by using `System.Version` which shouldn't be impacted by culture and is supported by MSBuild.